### PR TITLE
New: Automatic runtime support round two 💖

### DIFF
--- a/src/__snapshots__/index.spec.js.snap
+++ b/src/__snapshots__/index.spec.js.snap
@@ -75,7 +75,7 @@ Object {
       "@babel/preset-react",
       Object {
         "development": true,
-        "useBuiltIns": true,
+        "runtime": "automatic",
       },
     ],
     "@babel/preset-typescript",
@@ -124,7 +124,7 @@ Object {
       "@babel/preset-react",
       Object {
         "development": false,
-        "useBuiltIns": true,
+        "runtime": "automatic",
       },
     ],
     "@babel/preset-typescript",
@@ -173,7 +173,7 @@ Object {
       "@babel/preset-react",
       Object {
         "development": false,
-        "useBuiltIns": true,
+        "runtime": "automatic",
       },
     ],
     "@babel/preset-typescript",

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -2,28 +2,20 @@ jest.mock('path')
 
 import babelBase from '.'
 
-const mockEnv = (testEnv) => (envs) => {
-  if (typeof envs === 'string') {
-    return envs === testEnv
-  }
-
-  return envs.includes(testEnv)
-}
-
 describe('babelBase', () => {
   test('when called with target node, then node babel configs are returned', () => {
-    expect(babelBase({ env: mockEnv(), target: 'node' })).toMatchSnapshot()
+    expect(babelBase({ env: 'development', target: 'node' })).toMatchSnapshot()
   })
 
   test('when called with target react for dev, then development react configs are returned', () => {
-    expect(babelBase({ env: mockEnv('development'), target: 'react' })).toMatchSnapshot()
+    expect(babelBase({ env: 'development', target: 'react' })).toMatchSnapshot()
   })
 
   test('when called with target react for test, then test react configs are returned', () => {
-    expect(babelBase({ env: mockEnv('test'), target: 'react' })).toMatchSnapshot()
+    expect(babelBase({ env: 'test', target: 'react' })).toMatchSnapshot()
   })
 
   test('when called with target react for prod, then production react configs are returned', () => {
-    expect(babelBase({ env: mockEnv('production'), target: 'react' })).toMatchSnapshot()
+    expect(babelBase({ env: 'production', target: 'react' })).toMatchSnapshot()
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,11 +4,12 @@
 
 import { TransformOptions } from '@babel/core'
 
+import { Env } from './types'
 import nodeConfigs from './node'
 import reactConfigs from './react'
 
 type Options = {
-  env: (string) => boolean
+  env: Env
   target: 'node' | 'react'
 }
 

--- a/src/react.ts
+++ b/src/react.ts
@@ -3,9 +3,8 @@ import path from 'path'
 
 import { TransformOptions } from '@babel/core'
 
-// Is this available from Babel directly?
-type Envs = 'development' | 'production' | 'test'
-type Env = (env: Envs | Envs[]) => boolean
+import { Env } from './types'
+import { testEnv } from './test-env'
 
 /**
  * 📝 Babel configurations
@@ -64,7 +63,7 @@ export default function reactConfigs(env: Env): TransformOptions {
           // Transform modules to common js in test for Jest
           // Disable module transformation in dev and prod builds to allow
           // webpack to smart-manage modules.
-          modules: env('test') ? 'commonjs' : false,
+          modules: testEnv(env, ['test']) ? 'commonjs' : false,
           // Transforms the core-js and regenerator-runtime imports in index.js
           // to only the polyfills needed for the target environments
           useBuiltIns: 'entry',
@@ -77,9 +76,10 @@ export default function reactConfigs(env: Env): TransformOptions {
       // runtime which auto imports the functions that JSX transpiles to.
       // Development option toggles plugins that add references to source and
       // self on each component
-      ['@babel/preset-react', { development: env('development'), useBuiltIns: true }],
-      // Disabled until I can figure out why MDX fails with automatic runtime
-      // ['@babel/preset-react', { development: env('development'), runtime: 'automatic' }],
+      [
+        '@babel/preset-react',
+        { development: testEnv(env, ['development']), runtime: 'automatic' },
+      ],
 
       // Enable TypeScript usage 🔐
       '@babel/preset-typescript',
@@ -107,7 +107,7 @@ export default function reactConfigs(env: Env): TransformOptions {
       [
         '@babel/plugin-transform-runtime',
         {
-          useESModules: env(['development', 'production']),
+          useESModules: testEnv(env, ['development', 'production']),
           // https://github.com/babel/babel/issues/10261
           // eslint-disable-next-line
           version: require('@babel/helpers/package.json').version,

--- a/src/test-env.spec.js
+++ b/src/test-env.spec.js
@@ -1,0 +1,15 @@
+import { testEnv } from './test-env'
+
+describe('babelBase', () => {
+  test('returns true for a single environment', () => {
+    expect(testEnv('development', ['development'])).toBe(true)
+  })
+
+  test('returns true for a multiple environments', () => {
+    expect(testEnv('development', ['development', 'test'])).toBe(true)
+  })
+
+  test('returns false when unmatched', () => {
+    expect(testEnv('development', ['production'])).toBe(false)
+  })
+})

--- a/src/test-env.ts
+++ b/src/test-env.ts
@@ -1,0 +1,5 @@
+import { Env } from './types'
+
+/** Tests the current env against target envs for toggling features by environment */
+export const testEnv = (currentEnv: Env, targetEnvs: Env[]): boolean =>
+  targetEnvs.includes(currentEnv)

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,2 @@
+/** Supported environment values */
+export type Env = 'development' | 'production' | 'test'


### PR DESCRIPTION
BREAKING CHANGE: The env option should be changed to one of development, test, or production